### PR TITLE
MOB-25782 Revert previous commit

### DIFF
--- a/CXDurationPicker/CXDurationPickerUtils.m
+++ b/CXDurationPicker/CXDurationPickerUtils.m
@@ -31,7 +31,6 @@
 
 + (NSDate *)dateFromPickerDate:(CXDurationPickerDate)pickerDate {
     NSCalendar *calendar = [NSCalendar currentCalendar];
-    [calendar setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"GMT"]];
     
     return [calendar dateFromComponents:[CXDurationPickerUtils dateComponentsFromPickerDate:pickerDate]];
 }


### PR DESCRIPTION
Some user have date's flows through application related to a timezone(as current time zone) or not (UTC or GMT)
- So previous fix is not adapted for user who are working with timezone.
- and this previous commit  broke the convention from nsdate to Components end back, because one uses GMT and the other Local Time.
