### PR TITLE
todayForegroundColor is not taken into consideration

### DIFF
--- a/CXDurationPicker/CXDurationPickerDayView.m
+++ b/CXDurationPicker/CXDurationPickerDayView.m
@@ -142,7 +142,12 @@
     } else if (self.type == CXDurationPickerDayTypeTransit) {
         color = self.transitForegroundColor.CGColor;
     } else {
-        color = self.dayForegroundColor.CGColor;
+        if (self.isToday) {
+            color = self.todayForegroundColor.CGColor;
+        } else {
+            color = self.dayForegroundColor.CGColor;
+        }
+        
     }
     
     NSDictionary *attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/CXDurationPicker/UIColor+CXDurationDefaults.m
+++ b/CXDurationPicker/UIColor+CXDurationDefaults.m
@@ -76,7 +76,7 @@
 }
 
 + (UIColor *)defaultTodayForegroundColor {
-    return [UIColor whiteColor];
+    return [UIColor darkGrayColor];
 }
 
 + (UIColor *)defaultTransitBackgroundColor {


### PR DESCRIPTION
The variable todayForegroundColor was not coded and it did not change the label text color of "Today".
With this change it enable this configuration feature.
Consideration:
todayForegroundColor did never worked till now, and till now "Today" was colored using the same color of "DayForegroundColor". To prevent surprises with current consumers i have also changed the default color for "todayForegroundColor" to mach "DayForegroundColor" default color. In this way consumers that haven't noticed this bug will not get a different color after upgrading to this version.
Consumers that did change the color of "DayForegroundColor" in code will notice the difference
