### PR TITLE
MEX-4830 Unable to select transaction dates older than a year

### DIFF
--- a/CXDurationPicker/CXDurationPickerMonthView.m
+++ b/CXDurationPicker/CXDurationPickerMonthView.m
@@ -434,7 +434,8 @@
 }
 
 - (NSDate *)dateForFirstDayInSection:(NSInteger)section {
-    section = section - 12;
+    // Month start from five years ago
+    section = section - 60;
     
     NSDate *now = [_calendar dateFromComponents:[_calendar components:NSCalendarUnitYear|NSCalendarUnitMonth
                                                              fromDate:[NSDate date]]];


### PR DESCRIPTION
This is a temporary fix
Increase the range of the past up to five years